### PR TITLE
Fix issues

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,27 +3,27 @@ Copyright (c) 2015, German Neuroinformatics Node (G-Node)
 
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software
-   must display the following acknowledgement:
-   This product includes software developed by the G-Node.
-4. Neither the name of the G-Node nor the
-   names of its contributors may be used to endorse or promote products
-   derived from this software without specific prior written permission.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-THIS SOFTWARE IS PROVIDED BY G-NODE ''AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL G-NODE BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+1. Redistributions of source code must retain the above copyright notice, this list
+   of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may
+   be used to endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/checkstyleconfig.xml
+++ b/checkstyleconfig.xml
@@ -117,7 +117,7 @@
 
         <!-- Checks for common coding problems -->
         <module name="ArrayTrailingComma"/>
-        <module name="AvoidInlineConditionals"/>
+        <!--<module name="AvoidInlineConditionals"/>-->
         <module name="CovariantEquals"/>
         <!--<module name="DoubleCheckedLocking"/>-->
         <module name="EmptyStatement"/>

--- a/src/main/java/org/g_node/App.java
+++ b/src/main/java/org/g_node/App.java
@@ -103,7 +103,7 @@ public class App {
             final HelpFormatter printHelp = new HelpFormatter();
             final CommandLineParser parser = new DefaultParser();
             final Controller currCrawlerController = this.tools.get(args[0]);
-            final Options useOptions = this.tools.get(args[0]).options(this.tools.keySet());
+            final Options useOptions = this.tools.get(args[0]).options();
 
             try {
                 final CommandLine cmd = parser.parse(useOptions, args, false);

--- a/src/main/java/org/g_node/Controller.java
+++ b/src/main/java/org/g_node/Controller.java
@@ -10,7 +10,6 @@
 
 package org.g_node;
 
-import java.util.Set;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
@@ -23,11 +22,9 @@ public interface Controller {
     /**
      * Method returning available commandline options of the crawler
      * or converter corresponding to the command class.
-     * @param regTools Set of shorthand strings corresponding to
-     *  registered crawlers or converters.
      * @return Constructed set of commandline options.
      */
-    Options options(Set<String> regTools);
+    Options options();
 
     /**
      * Method running the crawler corresponding to the command class.

--- a/src/main/java/org/g_node/converter/ConvController.java
+++ b/src/main/java/org/g_node/converter/ConvController.java
@@ -14,7 +14,6 @@ import com.hp.hpl.jena.rdf.model.Model;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.cli.CommandLine;
@@ -38,10 +37,9 @@ public class ConvController implements Controller {
     private static final Logger LOGGER = Logger.getLogger(ConvController.class.getName());
     /**
      * Method returning the commandline options of the RDF to RDF converter.
-     * @param regTools Set of all registered tools.
      * @return Available commandline options.
      */
-    public final Options options(final Set<String> regTools) {
+    public final Options options() {
         final Options options = new Options();
 
         final Option opHelp = new Option("h", "help", false, "Print this message");

--- a/src/main/java/org/g_node/converter/ConvController.java
+++ b/src/main/java/org/g_node/converter/ConvController.java
@@ -15,13 +15,13 @@ import com.hp.hpl.jena.rdf.model.Model;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.jena.riot.RiotException;
 import org.apache.log4j.Logger;
 import org.g_node.Controller;
+import org.g_node.srv.CliOptionService;
 import org.g_node.srv.CtrlCheckService;
 import org.g_node.srv.RDFService;
 
@@ -42,41 +42,11 @@ public class ConvController implements Controller {
     public final Options options() {
         final Options options = new Options();
 
-        final Option opHelp = new Option("h", "help", false, "Print this message");
-
-        final Option opIn = Option.builder("i")
-                .longOpt("in-file")
-                .desc("Input RDF file that's supposed to be converted into a different RDF format.")
-                .required()
-                .hasArg()
-                .valueSeparator()
-                .build();
-
-        final Option opOut = Option.builder("o")
-                .longOpt("out-file")
-                .desc(
-                        String.join(
-                                "", "Optional: Path and name of the output file. ",
-                                "Files with the same name will be overwritten. ",
-                                "Default file name uses format [inputFileName]_out"
-                        )
-                )
-                .hasArg()
-                .valueSeparator()
-                .build();
-
-        final Option opFormat = Option.builder("f")
-                .longOpt("out-format")
-                .desc(
-                        String.join(
-                                "", "Optional: format of the RDF file that will be written.\n",
-                                "Supported file formats: ", RDFService.RDF_FORMAT_MAP.keySet().toString(),
-                                "\nDefault setting is the Turtle (TTL) format."
-                        )
-                )
-                .hasArg()
-                .valueSeparator()
-                .build();
+        final Option opHelp = CliOptionService.getHelpOpt("");
+        final Option opIn = CliOptionService.getInFileOpt(
+                "Input RDF file that's supposed to be converted into a different RDF format.");
+        final Option opOut = CliOptionService.getOutFileOpt("");
+        final Option opFormat = CliOptionService.getOutFormatOpt("");
 
         options.addOption(opHelp);
         options.addOption(opIn);

--- a/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogController.java
+++ b/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogController.java
@@ -19,6 +19,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.log4j.Logger;
 import org.g_node.Controller;
+import org.g_node.srv.CliOptionService;
 import org.g_node.srv.CtrlCheckService;
 import org.g_node.srv.RDFService;
 
@@ -63,41 +64,10 @@ public class LKTLogController implements Controller {
     public final Options options() {
         final Options options = new Options();
 
-        final Option opHelp = new Option("h", "help", false, "Print this message");
-
-        final Option opIn = Option.builder("i")
-                .longOpt("in-file")
-                .desc("Input file that's supposed to be parsed")
-                .required()
-                .hasArg()
-                .valueSeparator()
-                .build();
-
-        final Option opOut = Option.builder("o")
-                .longOpt("out-file")
-                .desc(
-                        String.join(
-                                "", "Optional: Path and name of the output file. ",
-                                "Files with the same name will be overwritten. ",
-                                "Default file name uses format [inputFileName]_out"
-                        )
-                )
-                .hasArg()
-                .valueSeparator()
-                .build();
-
-        final Option opFormat = Option.builder("f")
-                .longOpt("out-format")
-                .desc(
-                        String.join(
-                                "", "Optional: format of the RDF file that will be written.\n",
-                                "Supported file formats: ", RDFService.RDF_FORMAT_MAP.keySet().toString(),
-                                "\nDefault setting is the Turtle (TTL) format."
-                        )
-                )
-                .hasArg()
-                .valueSeparator()
-                .build();
+        final Option opHelp = CliOptionService.getHelpOpt("");
+        final Option opIn = CliOptionService.getInFileOpt("");
+        final Option opOut = CliOptionService.getOutFileOpt("");
+        final Option opFormat = CliOptionService.getOutFormatOpt("");
 
         options.addOption(opHelp);
         options.addOption(opIn);

--- a/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogController.java
+++ b/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogController.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -59,10 +58,9 @@ public class LKTLogController implements Controller {
 
     /**
      * Method returning the commandline options of the LKT crawler.
-     * @param regTools Set of all registered crawlers.
      * @return Available {@link CommandLine} {@link Options}.
      */
-    public final Options options(final Set<String> regTools) {
+    public final Options options() {
         final Options options = new Options();
 
         final Option opHelp = new Option("h", "help", false, "Print this message");

--- a/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParser.java
+++ b/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParser.java
@@ -165,33 +165,29 @@ public class LKTLogParser {
         final LKTLogParserSheet currLKTLSheet  = new LKTLogParserSheet();
         final String sheetName = currSheet.getName();
         ArrayList<String> parseSheetMessage;
-        String checkDB;
-        String checkDW;
+        String checkDateBirth;
+        String checkDateWithdrawal;
 
         currLKTLSheet.setSubjectID(currSheet.getCellAt("C2").getTextValue());
         currLKTLSheet.setSubjectSex(currSheet.getCellAt("C3").getTextValue());
-        checkDB = currLKTLSheet.setDateOfBirth(currSheet.getCellAt("C4").getTextValue());
-        checkDW = currLKTLSheet.setDateOfWithdrawal(currSheet.getCellAt("C5").getTextValue());
+        checkDateBirth = currLKTLSheet.setDateOfBirth(currSheet.getCellAt("C4").getTextValue());
+        checkDateWithdrawal = currLKTLSheet.setDateOfWithdrawal(currSheet.getCellAt("C5").getTextValue());
         currLKTLSheet.setPermitNumber(currSheet.getCellAt("C6").getTextValue());
         currLKTLSheet.setSpecies(currSheet.getCellAt("C7").getTextValue());
         currLKTLSheet.setScientificName(currSheet.getCellAt("C8").getTextValue());
 
         // TODO come up with a better way to deal with date errors
         parseSheetMessage = currLKTLSheet.isValidSheet();
-        if (!parseSheetMessage.isEmpty() || !checkDB.isEmpty() || !checkDW.isEmpty()) {
-            if (!parseSheetMessage.isEmpty()) {
-                parseSheetMessage.forEach(
-                        m -> this.parserErrorMessages.add(String.join("", "[Parser] sheet ", sheetName, ", ", m))
-                );
-            }
-            // Check valid date of birth
-            if (!checkDB.isEmpty()) {
-                this.parserErrorMessages.add(String.join("", "[Parser] sheet ", sheetName, ", ", checkDB));
-            }
-            // Check valid date of withdrawal
-            if (!checkDW.isEmpty()) {
-                this.parserErrorMessages.add(String.join("", "[Parser] sheet ", sheetName, ", ", checkDW));
-            }
+        if (!parseSheetMessage.isEmpty()) {
+            parseSheetMessage.forEach(
+                    m -> this.parserErrorMessages.add(String.join("", "[Parser] sheet ", sheetName, ", ", m))
+            );
+        }
+        if (!checkDateBirth.isEmpty()) {
+            this.parserErrorMessages.add(String.join("", "[Parser] sheet ", sheetName, ", ", checkDateBirth));
+        }
+        if (!checkDateWithdrawal.isEmpty()) {
+            this.parserErrorMessages.add(String.join("", "[Parser] sheet ", sheetName, ", ", checkDateWithdrawal));
         }
         return currLKTLSheet;
     }

--- a/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParser.java
+++ b/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParser.java
@@ -13,7 +13,6 @@ package org.g_node.crawler.LKTLogbook;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-
 import org.apache.log4j.Logger;
 import org.jopendocument.dom.spreadsheet.Sheet;
 import org.jopendocument.dom.spreadsheet.SpreadSheet;
@@ -49,6 +48,137 @@ public class LKTLogParser {
      * mistakes ideally all at once before running the crawler again.
      */
     private ArrayList<String> parserErrorMessages;
+    /**
+     * Enumeration required to access fields in the ODS file
+     * associated with basic information about the animal.
+     */
+    private enum AnFieldRange {
+        /**
+         * Animal SubjectID.
+         */
+        SUBJID ("C2"),
+        /**
+         * Animal Sex.
+         */
+        SUBJSEX("C3"),
+        /**
+         * Animal date of birth.
+         */
+        DATEBIRTH("C4"),
+        /**
+         * Animal date of withdrawal from animal housing.
+         */
+        DATEWITHDRAWAL("C5"),
+        /**
+         * Permit number associated with the animal.
+         */
+        PERMITNR("C6"),
+        /**
+         * Common name associated with the animal.
+         */
+        SPECIES("C7"),
+        /**
+         * Animal scientific name.
+         */
+        SCIENTIFICNAME("C8");
+        /**
+         * Field in the ODS sheet where the information of the current enumeration will be parsed from.
+         */
+        private final String field;
+        /**
+         * Enum constructor. Sets the ODS field associated with the current enumeration.
+         * @param odsField String with the ODS field associated with the current enumeration.
+         */
+        AnFieldRange(final String odsField) {
+            this.field = odsField;
+        }
+        /**
+         * Returns the ODS field associated with the current enumeration.
+         * @return See description.
+         */
+        private String getField() {
+            return this.field;
+        }
+    }
+
+    /**
+     * Enumeration required to access columns in the ODS file
+     * associated with information about experiments and log entries.
+     */
+    private enum EntryFieldRange {
+        /**
+         * ID whether the entry has already been imported or not.
+         * Should not be used any more.
+         */
+        IMPORTID("A"),
+        /**
+         * Date and time an experiment has been performed.
+         */
+        DATEEXPERIMENT("B"),
+        /**
+         * Identifier string for the paradigm.
+         */
+        PARADIGM("C"),
+        /**
+         * Specifics of the paradigm.
+         */
+        PARADIGMSPEC("D"),
+        /**
+         * States if the animal is on diet or not.
+         */
+        ISONDIET("E"),
+        /**
+         * States if the entry is used as initial weight or not.
+         */
+        ISINITIALWEIGHT("F"),
+        /**
+         * Weight of the animal.
+         */
+        WEIGHT("G"),
+        /**
+         * Comment about an experiment.
+         */
+        COMMENTEXPERIMENT("H"),
+        /**
+         * Animal log entry.
+         */
+        COMMENTANIMAL("I"),
+        /**
+         * Feed of the animal.
+         */
+        FEED("J"),
+        /**
+         * Identifier string of the project.
+         */
+        PROJECT("K"),
+        /**
+         * Identifier string of the experiment.
+         */
+        EXPERIMENT("L"),
+        /**
+         * Full name of the experimenter.
+         */
+        EXPERIMENTER("M");
+        /**
+         * Column in the ODS sheet where the information of the current enumeration will be parsed from.
+         */
+        private final String column;
+
+        /**
+         * Enum constructor. Sets the ODS column associated with the current enumeration.
+         * @param odsColumn String with the ODS column associated with the current enumeration.
+         */
+        EntryFieldRange(final String odsColumn) {
+            this.column = odsColumn;
+        }
+        /**
+         * Returns the ODS column associated with the current enumeration.
+         * @return See description.
+         */
+        private String getColumn() {
+            return this.column;
+        }
+    }
     /**
      * Method for parsing the contents of a provided ODS input file.
      * This method will create a backup file of the original ODS file.
@@ -132,7 +262,8 @@ public class LKTLogParser {
                     if (checkHeaderCell == null || !checkHeaderCell.equals(LKTLogParser.FIRST_HEADER_ENTRY)) {
                         this.parserErrorMessages.add(String.join(
                                 "", "[Parser] sheet ", sheetName,
-                                ", HeaderEntry 'ImportID' not found at required line A.",
+                                ", HeaderEntry '", LKTLogParser.FIRST_HEADER_ENTRY,
+                                "' not found at required line ", EntryFieldRange.IMPORTID.getColumn(), ".",
                                 String.valueOf(LKTLogParser.SHEET_HEADER_LINE)
                         ));
 
@@ -163,13 +294,20 @@ public class LKTLogParser {
         String checkDateBirth;
         String checkDateWithdrawal;
 
-        currLKTLSheet.setSubjectID(currSheet.getCellAt("C2").getTextValue());
-        currLKTLSheet.setSubjectSex(currSheet.getCellAt("C3").getTextValue());
-        checkDateBirth = currLKTLSheet.setDateOfBirth(currSheet.getCellAt("C4").getTextValue());
-        checkDateWithdrawal = currLKTLSheet.setDateOfWithdrawal(currSheet.getCellAt("C5").getTextValue());
-        currLKTLSheet.setPermitNumber(currSheet.getCellAt("C6").getTextValue());
-        currLKTLSheet.setSpecies(currSheet.getCellAt("C7").getTextValue());
-        currLKTLSheet.setScientificName(currSheet.getCellAt("C8").getTextValue());
+        currLKTLSheet.setSubjectID(
+                currSheet.getCellAt(AnFieldRange.SUBJID.getField()).getTextValue());
+        currLKTLSheet.setSubjectSex(
+                currSheet.getCellAt(AnFieldRange.SUBJSEX.getField()).getTextValue());
+        checkDateBirth = currLKTLSheet.setDateOfBirth(
+                currSheet.getCellAt(AnFieldRange.DATEBIRTH.getField()).getTextValue());
+        checkDateWithdrawal = currLKTLSheet.setDateOfWithdrawal(
+                currSheet.getCellAt(AnFieldRange.DATEWITHDRAWAL.getField()).getTextValue());
+        currLKTLSheet.setPermitNumber(
+                currSheet.getCellAt(AnFieldRange.PERMITNR.getField()).getTextValue());
+        currLKTLSheet.setSpecies(
+                currSheet.getCellAt(AnFieldRange.SPECIES.getField()).getTextValue());
+        currLKTLSheet.setScientificName(
+                currSheet.getCellAt(AnFieldRange.SCIENTIFICNAME.getField()).getTextValue());
 
         // TODO come up with a better way to deal with date errors
         parseSheetMessage = currLKTLSheet.isValidSheet();
@@ -236,14 +374,18 @@ public class LKTLogParser {
 
         final LKTLogParserEntry currEntry = new LKTLogParserEntry();
 
-        currEntry.setProject(currSheet.getCellAt(String.join("", "K", currLine)).getTextValue());
-        currEntry.setExperiment(currSheet.getCellAt(String.join("", "L", currLine)).getTextValue());
-        currEntry.setParadigm(currSheet.getCellAt(String.join("", "C", currLine)).getTextValue());
-        currEntry.setParadigmSpecifics(currSheet.getCellAt(String.join("", "D", currLine)).getTextValue());
+        currEntry.setProject(currSheet.getCellAt(
+                String.join("", EntryFieldRange.PROJECT.getColumn(), currLine)).getTextValue());
+        currEntry.setExperiment(currSheet.getCellAt(
+                String.join("", EntryFieldRange.EXPERIMENT.getColumn(), currLine)).getTextValue());
+        currEntry.setParadigm(currSheet.getCellAt(
+                String.join("", EntryFieldRange.PARADIGM.getColumn(), currLine)).getTextValue());
+        currEntry.setParadigmSpecifics(currSheet.getCellAt(
+                String.join("", EntryFieldRange.PARADIGMSPEC.getColumn(), currLine)).getTextValue());
 
         // TODO Check if the experimentDate parser error and the empty line messages all still work!
         checkExperimentDate = currEntry.setExperimentDate(currSheet.getCellAt(
-                String.join("", "B", currLine)).getTextValue()
+                String.join("", EntryFieldRange.DATEEXPERIMENT.getColumn(), currLine)).getTextValue()
         );
         if (!checkExperimentDate.isEmpty()) {
             this.parserErrorMessages.add(String.join(
@@ -252,14 +394,21 @@ public class LKTLogParser {
             ));
         }
 
-        currEntry.setExperimenterName(currSheet.getCellAt(String.join("", "M", currLine)).getTextValue());
-        currEntry.setCommentExperiment(currSheet.getCellAt(String.join("", "H", currLine)).getTextValue());
-        currEntry.setCommentSubject(currSheet.getCellAt(String.join("", "I", currLine)).getTextValue());
-        currEntry.setFeed(currSheet.getCellAt(String.join("", "J", currLine)).getTextValue());
-        currEntry.setIsOnDiet(currSheet.getCellAt(String.join("", "E", currLine)).getTextValue());
-        currEntry.setIsInitialWeight(currSheet.getCellAt(String.join("", "F", currLine)).getTextValue());
+        currEntry.setExperimenterName(currSheet.getCellAt(
+                String.join("", EntryFieldRange.EXPERIMENTER.getColumn(), currLine)).getTextValue());
+        currEntry.setCommentExperiment(currSheet.getCellAt(
+                String.join("", EntryFieldRange.COMMENTEXPERIMENT.getColumn(), currLine)).getTextValue());
+        currEntry.setCommentSubject(currSheet.getCellAt(
+                String.join("", EntryFieldRange.COMMENTANIMAL.getColumn(), currLine)).getTextValue());
+        currEntry.setFeed(currSheet.getCellAt(
+                String.join("", EntryFieldRange.FEED.getColumn(), currLine)).getTextValue());
+        currEntry.setIsOnDiet(currSheet.getCellAt(
+                String.join("", EntryFieldRange.ISONDIET.getColumn(), currLine)).getTextValue());
+        currEntry.setIsInitialWeight(currSheet.getCellAt(
+                String.join("", EntryFieldRange.ISINITIALWEIGHT.getColumn(), currLine)).getTextValue());
 
-        final String currMsg = currEntry.setWeight(currSheet.getCellAt(String.join("", "G", currLine)).getTextValue());
+        final String currMsg = currEntry.setWeight(currSheet.getCellAt(
+                String.join("", EntryFieldRange.WEIGHT.getColumn(), currLine)).getTextValue());
         if (!"".equals(currMsg)) {
             this.parserErrorMessages.add(String.join(
                     "", "[Parser] sheet ", currSheet.getName(),

--- a/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParser.java
+++ b/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParser.java
@@ -68,33 +68,28 @@ public class LKTLogParser {
         try {
             final File odsFile = new File(inputFile);
 
+            // TODO will raise a null pointer exception, if the file is not an actual ODS file.
             LKTLogParser.LOGGER.info(
                     String.join(
                             "", "File has # sheets: ",
                             String.valueOf(SpreadSheet.createFromFile(odsFile).getSheetCount()))
             );
 
-            if (!(SpreadSheet.createFromFile(odsFile).getSheetCount() > 0)) {
-                this.parserErrorMessages.add(String.join(
-                        "", "[Parser] File ", inputFile,
-                        " does not contain valid data sheets."
-                ));
-            } else {
-                allSheets = this.parseSheets(odsFile);
-                allSheets.forEach(
-                        s -> LKTLogParser.LOGGER.info(
-                                String.join(
-                                        "", "CurrSheet: ", s.getSubjectID(),
-                                        ", number of entries: ", String.valueOf(s.getEntries().size())
-                                )
-                        )
-                );
+            allSheets = this.parseSheets(odsFile);
+            allSheets.forEach(
+                    s -> LKTLogParser.LOGGER.info(
+                            String.join(
+                                    "", "CurrSheet: ", s.getSubjectID(),
+                                    ", number of entries: ", String.valueOf(s.getEntries().size())
+                            )
+                    )
+            );
 
-                if (this.parserErrorMessages.size() > 0) {
-                    this.parserErrorMessages.add(
-                            "\n\tThere are parser errors present. Please resolve them and run the program again.");
-                }
+            if (this.parserErrorMessages.size() > 0) {
+                this.parserErrorMessages.add(
+                        "\n\tThere are parser errors present. Please resolve them and run the program again.");
             }
+
         } catch (final IOException exp) {
             this.parserErrorMessages.add(String.join("", "[Error] reading from input file: ", exp.getMessage()));
             exp.printStackTrace();

--- a/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParserEntry.java
+++ b/src/main/java/org/g_node/crawler/LKTLogbook/LKTLogParserEntry.java
@@ -225,7 +225,7 @@ public class LKTLogParserEntry {
      * @param exn Name of the experimenter.
      */
     public final void setExperimenterName(final String exn) {
-        if (this.experimenterName != null && !this.experimenterName.isEmpty()) {
+        if (exn != null && !exn.isEmpty()) {
             this.setIsEmptyLine(false);
         }
         this.experimenterName = exn;

--- a/src/main/java/org/g_node/srv/CliOptionService.java
+++ b/src/main/java/org/g_node/srv/CliOptionService.java
@@ -16,34 +16,36 @@ import org.apache.commons.cli.Option;
  * Class provides CLI {@link Option}s that are common
  * to all crawlers and converters of this service.
  */
-public class CliOptionService {
+public final class CliOptionService {
 
     /**
      * Returns help option.
-     * @param desc Optional description.
+     * @param altDesc Optional description.
      * @return Help option.
      */
-    public final Option getHelpOpt(final String desc) {
+    public static Option getHelpOpt(final String altDesc) {
 
         final String defaultDesc = "Print this message.";
+        final String desc = !altDesc.isEmpty() ? altDesc : defaultDesc;
 
-        return new Option("h", "help", false, !desc.isEmpty() ? desc : defaultDesc);
+        return new Option("h", "help", false, desc);
     }
 
     /**
      * Returns option required to parse a given input file name from the command line.
      * Commandline option shorthand will always be "-i" and "-in-file". This
      * option will always be "required".
-     * @param desc Alternative description replacing the default description.
+     * @param altDesc Alternative description replacing the default description.
      * @return Required CLI option parsing an input file.
      */
-    public final Option getInFileOpt(final String desc) {
+    public static Option getInFileOpt(final String altDesc) {
 
         final String defaultDesc = "Input file that's supposed to be parsed.";
+        final String desc = !altDesc.isEmpty() ? altDesc : defaultDesc;
 
         return Option.builder("i")
                 .longOpt("in-file")
-                .desc(!desc.isEmpty() ? desc : defaultDesc)
+                .desc(desc)
                 .required()
                 .hasArg()
                 .valueSeparator()
@@ -53,19 +55,20 @@ public class CliOptionService {
     /**
      * Returns option required to parse a given output file name from the command line.
      * Commandline option shorthand will always be "-o" and "-out-file".
-     * @param desc Alternative description replacing the default description.
+     * @param altDesc Alternative description replacing the default description.
      * @return CLI option parsing an input file.
      */
-    public final Option getOutFileOpt(final String desc) {
+    public static Option getOutFileOpt(final String altDesc) {
 
         final String defaultDesc = String.join(
                 "", "Optional: Path and name of the output file. ",
                 "Files with the same name will be overwritten. ",
-                "Default file name uses format [inputFileName]_out");
+                "Default file name uses format [inputFileName]_out.");
+        final String desc = !altDesc.isEmpty() ? altDesc : defaultDesc;
 
         return  Option.builder("o")
                 .longOpt("out-file")
-                .desc(!desc.isEmpty() ? desc : defaultDesc)
+                .desc(desc)
                 .hasArg()
                 .valueSeparator()
                 .build();
@@ -74,19 +77,20 @@ public class CliOptionService {
     /**
      * Returns option required to parse a given output format from the command line.
      * Commandline option shorthand will always be "-f" and "-out-format".
-     * @param desc Alternative description replacing the default description.
+     * @param altDesc Alternative description replacing the default description.
      * @return CLI option parsing an input file.
      */
-    public final Option getOutFormatOpt(final String desc) {
+    public static Option getOutFormatOpt(final String altDesc) {
 
         final String defaultDesc = String.join(
                 "", "Optional: format of the RDF file that will be written.\n",
                 "Supported file formats: ", RDFService.RDF_FORMAT_MAP.keySet().toString(),
                 "\nDefault setting is the Turtle (TTL) format.");
+        final String desc = !altDesc.isEmpty() ? altDesc : defaultDesc;
 
         return Option.builder("f")
                 .longOpt("out-format")
-                .desc(!desc.isEmpty() ? desc : defaultDesc)
+                .desc(desc)
                 .hasArg()
                 .valueSeparator()
                 .build();

--- a/src/main/java/org/g_node/srv/CliOptionService.java
+++ b/src/main/java/org/g_node/srv/CliOptionService.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2015, German Neuroinformatics Node (G-Node)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted under the terms of the BSD License. See
+ * LICENSE file in the root of the Project.
+ */
+
+package org.g_node.srv;
+
+import org.apache.commons.cli.Option;
+
+/**
+ * Class provides CLI {@link Option}s that are common
+ * to all crawlers and converters of this service.
+ */
+public class CliOptionService {
+
+    /**
+     * Returns help option.
+     * @param desc Optional description.
+     * @return Help option.
+     */
+    public final Option getHelpOpt(final String desc) {
+
+        final String defaultDesc = "Print this message.";
+
+        return new Option("h", "help", false, !desc.isEmpty() ? desc : defaultDesc);
+    }
+
+    /**
+     * Returns option required to parse a given input file name from the command line.
+     * Commandline option shorthand will always be "-i" and "-in-file". This
+     * option will always be "required".
+     * @param desc Alternative description replacing the default description.
+     * @return Required CLI option parsing an input file.
+     */
+    public final Option getInFileOpt(final String desc) {
+
+        final String defaultDesc = "Input file that's supposed to be parsed.";
+
+        return Option.builder("i")
+                .longOpt("in-file")
+                .desc(!desc.isEmpty() ? desc : defaultDesc)
+                .required()
+                .hasArg()
+                .valueSeparator()
+                .build();
+    }
+
+    /**
+     * Returns option required to parse a given output file name from the command line.
+     * Commandline option shorthand will always be "-o" and "-out-file".
+     * @param desc Alternative description replacing the default description.
+     * @return CLI option parsing an input file.
+     */
+    public final Option getOutFileOpt(final String desc) {
+
+        final String defaultDesc = String.join(
+                "", "Optional: Path and name of the output file. ",
+                "Files with the same name will be overwritten. ",
+                "Default file name uses format [inputFileName]_out");
+
+        return  Option.builder("o")
+                .longOpt("out-file")
+                .desc(!desc.isEmpty() ? desc : defaultDesc)
+                .hasArg()
+                .valueSeparator()
+                .build();
+    }
+
+    /**
+     * Returns option required to parse a given output format from the command line.
+     * Commandline option shorthand will always be "-f" and "-out-format".
+     * @param desc Alternative description replacing the default description.
+     * @return CLI option parsing an input file.
+     */
+    public final Option getOutFormatOpt(final String desc) {
+
+        final String defaultDesc = String.join(
+                "", "Optional: format of the RDF file that will be written.\n",
+                "Supported file formats: ", RDFService.RDF_FORMAT_MAP.keySet().toString(),
+                "\nDefault setting is the Turtle (TTL) format.");
+
+        return Option.builder("f")
+                .longOpt("out-format")
+                .desc(!desc.isEmpty() ? desc : defaultDesc)
+                .hasArg()
+                .valueSeparator()
+                .build();
+    }
+}

--- a/src/test/java/org/g_node/converter/ConvControllerTest.java
+++ b/src/test/java/org/g_node/converter/ConvControllerTest.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConvControllerTest {
 
     private ConvController convCont = new ConvController();
-    private Set<String> convSet = new HashSet<>(Arrays.asList("one", "two"));
 
     /**
      * Ensure a fresh {@link ConvController} at the beginning of each test.
@@ -55,7 +54,7 @@ public class ConvControllerTest {
      */
     @Test
     public void optionsTest() {
-        Options checkOpt = this.convCont.options(this.convSet);
+        Options checkOpt = this.convCont.options();
 
         assertThat(checkOpt.getOptions().size()).isEqualTo(4);
 
@@ -118,7 +117,7 @@ public class ConvControllerTest {
         final String outFileName = testFileFolder.resolve("out.ttl").toString();
 
         final CommandLineParser parser = new DefaultParser();
-        final Options useOptions = this.convCont.options(this.convSet);
+        final Options useOptions = this.convCont.options();
         String[] args;
         CommandLine cmd;
 

--- a/src/test/java/org/g_node/crawler/LKTLogbook/LKTLogControllerTest.java
+++ b/src/test/java/org/g_node/crawler/LKTLogbook/LKTLogControllerTest.java
@@ -45,7 +45,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LKTLogControllerTest {
 
     private LKTLogController logCtrl;
-    private Set<String> logSet = new HashSet<>(Arrays.asList("one", "two"));
     private PrintStream stdout;
     private ByteArrayOutputStream outStream;
     private Logger rootLogger;
@@ -101,7 +100,7 @@ public class LKTLogControllerTest {
      */
     @Test
     public void testOptions() throws Exception {
-        Options checkOpt = this.logCtrl.options(this.logSet);
+        Options checkOpt = this.logCtrl.options();
 
         assertThat(checkOpt.getOptions().size()).isEqualTo(4);
 
@@ -133,7 +132,7 @@ public class LKTLogControllerTest {
         SpreadSheet.createEmpty(new DefaultTableModel()).saveAs(ods);
 
         final CommandLineParser parser = new DefaultParser();
-        final Options useOptions = this.logCtrl.options(this.logSet);
+        final Options useOptions = this.logCtrl.options();
         String[] args;
         CommandLine cmd;
 
@@ -219,7 +218,7 @@ public class LKTLogControllerTest {
         FileUtils.write(currOutFile, "");
 
         final CommandLineParser parser = new DefaultParser();
-        final Options useOptions = this.logCtrl.options(this.logSet);
+        final Options useOptions = this.logCtrl.options();
         String[] args;
         CommandLine cmd;
 


### PR DESCRIPTION
Fixed issues:
- conditional in experimenter name was never accessed due to faulty logic.
- removed redundant conditionals when checking for parser messages and existing date of birth and date of withdrawal.
- removed check for number of sheets in an ODS file. A valid ODS file always has at least one sheet, the check is therefore not required at this point in the code.

Refactoring:
- added enums to remove magic entries (ODS columns and fields) from the code when parsing the ODS sheet.
- removed argument from the controller.option method. This argument (set of tools) was required in a previous version of the crawler but is actually not needed any longer.
- refactored the handling of controller cli options to reduce redundancies.

Additional stuff:
- change the checkstyle ruleset; will now allow inline conditionals (because I like them).
- change license to BSD-3 clause.
