### PR TITLE
Add hash ID as RDF class instance identifier

### DIFF
--- a/src/main/java/org/g_node/srv/RDFUtils.java
+++ b/src/main/java/org/g_node/srv/RDFUtils.java
@@ -63,7 +63,14 @@ public final class RDFUtils {
      * Dublin core Namespace prefix.
      */
     public static final String RDF_NS_DC_ABR = "dc";
-
+    /**
+     * Core Ontology for neuroscientific metadata defined by the G-Node.
+      */
+    public static final String RDF_NS_GN_ONT = "https://github.com/G-Node/neuro-ontology/";
+    /**
+     * G-Node ontology namespace prefix.
+     */
+    public static final String RDF_NS_GN_ONT_ABR = "gn";
     /**
      * Method adds an RDF Literal only to a Jena Resource, if the Literal String
      * actually contains a value.

--- a/src/main/java/org/g_node/srv/Utils.java
+++ b/src/main/java/org/g_node/srv/Utils.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015, German Neuroinformatics Node (G-Node)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted under the terms of the BSD License. See
+ * LICENSE file in the root of the Project.
+ */
+
+package org.g_node.srv;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * Class providing various utility methods.
+ *
+ * @author Michael Sonntag (sonntag@bio.lmu.de)
+ */
+public final class Utils {
+    /**
+     * Method converts a List of Strings to Uppercase, joins the individual entries by a blank space
+     * and retrieves a hexadecimal String from the resulting input String using the SHA256 hash algorithm.
+     * @param valueList List of Strings.
+     * @return Hexadecimal String of the SHA256 encoded input Strings.
+     */
+    public static String getHashSHA256(final List<String> valueList) {
+
+        final String collectListValues = valueList.stream()
+                .map(s -> s.toUpperCase(Locale.ENGLISH))
+                .collect(Collectors.joining(" "));
+
+        return DigestUtils.sha256Hex(collectListValues);
+    }
+
+}

--- a/src/main/java/org/g_node/srv/Utils.java
+++ b/src/main/java/org/g_node/srv/Utils.java
@@ -22,18 +22,16 @@ import org.apache.commons.codec.digest.DigestUtils;
  */
 public final class Utils {
     /**
-     * Method converts a List of Strings to Uppercase, joins the individual entries by a blank space
-     * and retrieves a hexadecimal String from the resulting input String using the SHA256 hash algorithm.
+     * Method converts a List of Strings to upper case, joins the individual entries by a blank space
+     * and retrieves a hexadecimal String from the resulting input String using the SHA-1 hash algorithm.
      * @param valueList List of Strings.
-     * @return Hexadecimal String of the SHA256 encoded input Strings.
+     * @return Hexadecimal String of the SHA-1 encoded input Strings.
      */
-    public static String getHashSHA256(final List<String> valueList) {
-
+    public static String getHashSHA(final List<String> valueList) {
         final String collectListValues = valueList.stream()
                 .map(s -> s.toUpperCase(Locale.ENGLISH))
                 .collect(Collectors.joining(" "));
 
-        return DigestUtils.sha256Hex(collectListValues);
+        return DigestUtils.shaHex(collectListValues);
     }
-
 }

--- a/src/test/java/org/g_node/srv/UtilsTest.java
+++ b/src/test/java/org/g_node/srv/UtilsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015, German Neuroinformatics Node (G-Node)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted under the terms of the BSD License. See
+ * LICENSE file in the root of the Project.
+ */
+
+package org.g_node.srv;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the {@link Utils} class.
+ *
+ * @author Michael Sonntag (sonntag@bio.lmu.de)
+ */
+public final class UtilsTest {
+
+    /**
+     * Method checks that the {@link Utils} getHashSHA256 method returns
+     * the proper hex hash for a List of String entries.
+     */
+    @Test
+    public void testGetHashSHA256() {
+        final String checkHexSHA256 = "c82b1b9a0ef4f87e13050b542881d1d158014e6d575f8efa7c4e2043b8c0cdf1";
+
+        final ArrayList<String> testHashLower = new ArrayList<>(Arrays.asList("hash", "me"));
+        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testHashLower))).isTrue();
+
+        final ArrayList<String> testHashMixed = new ArrayList<>(Arrays.asList("Hash", "Me"));
+        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testHashMixed))).isTrue();
+
+        final List<String> testHashSingleEntry = Collections.singletonList("Hash me");
+        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testHashSingleEntry))).isTrue();
+
+        final List<String> testDiff = Collections.singletonList("hashme");
+        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testDiff))).isFalse();
+    }
+}

--- a/src/test/java/org/g_node/srv/UtilsTest.java
+++ b/src/test/java/org/g_node/srv/UtilsTest.java
@@ -26,23 +26,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 public final class UtilsTest {
 
     /**
-     * Method checks that the {@link Utils} getHashSHA256 method returns
+     * Method checks that the {@link Utils} getHashSHA method returns
      * the proper hex hash for a List of String entries.
      */
     @Test
-    public void testGetHashSHA256() {
-        final String checkHexSHA256 = "c82b1b9a0ef4f87e13050b542881d1d158014e6d575f8efa7c4e2043b8c0cdf1";
+    public void testGetHashSHA() {
+        final String checkHexSHA = "e5c055cdf43af5be8972d5a94c8d0182296de89b";
 
         final ArrayList<String> testHashLower = new ArrayList<>(Arrays.asList("hash", "me"));
-        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testHashLower))).isTrue();
+        assertThat(checkHexSHA.equals(Utils.getHashSHA(testHashLower))).isTrue();
 
         final ArrayList<String> testHashMixed = new ArrayList<>(Arrays.asList("Hash", "Me"));
-        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testHashMixed))).isTrue();
+        assertThat(checkHexSHA.equals(Utils.getHashSHA(testHashMixed))).isTrue();
 
         final List<String> testHashSingleEntry = Collections.singletonList("Hash me");
-        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testHashSingleEntry))).isTrue();
+        assertThat(checkHexSHA.equals(Utils.getHashSHA(testHashSingleEntry))).isTrue();
 
         final List<String> testDiff = Collections.singletonList("hashme");
-        assertThat(checkHexSHA256.equals(Utils.getHashSHA256(testDiff))).isFalse();
+        assertThat(checkHexSHA.equals(Utils.getHashSHA(testDiff))).isFalse();
     }
 }


### PR DESCRIPTION
- added util method returning a hex hash string from a list of strings
- refactored all usages of UUIDs as RDF class instance indentifiers with hashIDs
- added documentation and tests